### PR TITLE
feat: 미로 게임 구현 (#30)

### DIFF
--- a/g_maze/css/g_maze.css
+++ b/g_maze/css/g_maze.css
@@ -1,0 +1,197 @@
+#maze-guide {
+  width: 100%;
+  padding: 14px 18px;
+  background-color: #2ecc71;
+  color: #fff;
+  font-size: 20px;
+  font-weight: bold;
+  text-align: center;
+  position: relative;
+  z-index: 10;
+  box-sizing: border-box;
+}
+
+#container {
+  position: relative;
+  width: 100%;
+  height: calc(100vh - 60px);
+  overflow: hidden;
+  background-color: #1a1a2e;
+}
+
+#maze-area {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  cursor: none;
+  overflow: hidden;
+}
+
+#maze-area > div {
+  position: absolute;
+  box-sizing: border-box;
+}
+
+#maze-cursor {
+  position: absolute;
+  width: 14px;
+  height: 14px;
+  background-color: #fff;
+  border: 2px solid #333;
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: 30;
+  transform: translate(-50%, -50%);
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.6);
+  display: none;
+}
+
+.path {
+  background-color: #e8d5b7;
+  z-index: 2;
+}
+
+.wall {
+  background-color: #2c3e50;
+  z-index: 1;
+}
+
+.obstacle {
+  background-color: #e74c3c;
+  border-radius: 4px;
+  z-index: 5;
+}
+
+#start-point {
+  background-color: #2ecc71;
+  border-radius: 50%;
+  z-index: 6;
+}
+
+#start-point.waiting {
+  animation: start-pulse 1s ease-in-out infinite;
+}
+
+@keyframes start-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(46, 204, 113, 0.7);
+  }
+  50% {
+    box-shadow: 0 0 0 10px rgba(46, 204, 113, 0);
+  }
+}
+
+#end-point {
+  background-color: #f1c40f;
+  border-radius: 50%;
+  z-index: 6;
+}
+
+#ui {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 20;
+}
+
+#message {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  text-align: center;
+  background: rgba(0, 0, 0, 0.6);
+  color: white;
+  padding: 24px 36px;
+  border-radius: 16px;
+  pointer-events: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
+#message.hidden {
+  display: none !important;
+}
+
+.btn-row {
+  display: flex;
+  gap: 12px;
+}
+
+#start-btn,
+#retry-btn,
+#next-btn {
+  padding: 20px 48px;
+  color: white;
+  font-size: 20px;
+  font-weight: 600;
+  border-radius: 16px;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+  transition:
+    transform 0.4s ease,
+    background-color 0.2s;
+  outline: none;
+}
+
+#start-btn {
+  background-color: #2e3d54;
+}
+
+#start-btn:hover {
+  transform: scale(1.08);
+  background-color: #546278;
+}
+
+#retry-btn,
+#next-btn {
+  background-color: #22c55e;
+}
+
+#retry-btn:hover,
+#next-btn:hover {
+  transform: scale(1.08);
+  background-color: #4ade80;
+}
+
+#start-btn:active,
+#retry-btn:active,
+#next-btn:active {
+  transform: scale(0.92);
+}
+
+#fail-btn {
+  padding: 20px 48px;
+  color: white;
+  font-size: 20px;
+  font-weight: 600;
+  border-radius: 16px;
+  background-color: #ef4444;
+  border: none;
+  cursor: pointer;
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+  transition:
+    transform 0.4s ease,
+    background-color 0.2s;
+  outline: none;
+}
+
+#fail-btn:hover {
+  transform: scale(1.08);
+  background-color: #f87171;
+}
+
+#fail-btn:active {
+  transform: scale(0.92);
+}
+
+.hidden {
+  display: none !important;
+}

--- a/g_maze/js/g_maze.js
+++ b/g_maze/js/g_maze.js
@@ -1,0 +1,235 @@
+const container = document.getElementById('container');
+const mazeArea = document.getElementById('maze-area');
+const messageEl = document.getElementById('message');
+const startBtn = document.getElementById('start-btn');
+const failBtns = document.getElementById('fail-btns');
+const retryBtn = document.getElementById('retry-btn');
+const failBtn = document.getElementById('fail-btn');
+const nextBtn = document.getElementById('next-btn');
+const cursorEl = document.getElementById('maze-cursor');
+
+let gameRunning = false;
+let gameEnded = false;
+let obstacles = [];
+let animFrameId = null;
+
+let mouseX = 0;
+let mouseY = 0;
+let mouseInsideMaze = false;
+
+const CURSOR_RADIUS = 7;
+
+const MAZE_LAYOUT = [
+  { type: 'wall', x: 0, y: 0, w: 100, h: 100 },
+
+  { type: 'path', x: 5, y: 8, w: 85, h: 7 },
+  { type: 'path', x: 82, y: 8, w: 8, h: 39 },
+
+  { type: 'path', x: 55, y: 40, w: 35, h: 7 },
+  { type: 'path', x: 55, y: 40, w: 7, h: 23 },
+  { type: 'path', x: 28, y: 56, w: 34, h: 7 },
+  { type: 'path', x: 28, y: 40, w: 7, h: 23 },
+  { type: 'path', x: 5, y: 40, w: 30, h: 7 },
+
+  { type: 'path', x: 5, y: 40, w: 8, h: 35 },
+  { type: 'path', x: 5, y: 68, w: 85, h: 7 },
+
+  { type: 'start', x: 6, y: 9, w: 5, h: 5 },
+  { type: 'end', x: 83, y: 69, w: 5, h: 5 },
+
+  { type: 'obstacle', x: 84, y: 20, w: 4, h: 5, range: 12, speed: 0.18 },
+  { type: 'obstacle', x: 7, y: 52, w: 4, h: 5, range: 10, speed: 0.15 },
+];
+
+function buildMaze() {
+  mazeArea.innerHTML = '';
+  obstacles = [];
+
+  MAZE_LAYOUT.forEach((item) => {
+    const el = document.createElement('div');
+    el.style.left = item.x + '%';
+    el.style.top = item.y + '%';
+    el.style.width = item.w + '%';
+    el.style.height = item.h + '%';
+
+    if (item.type === 'wall') {
+      el.classList.add('wall');
+      el.addEventListener('mouseenter', () => {
+        if (gameRunning && !gameEnded) endGame(false);
+      });
+    }
+
+    if (item.type === 'path') {
+      el.classList.add('path');
+    }
+
+    if (item.type === 'obstacle') {
+      el.classList.add('obstacle');
+      obstacles.push({
+        el,
+        startY: item.y,
+        range: item.range,
+        speed: item.speed,
+        dir: 1,
+        cur: 0,
+      });
+      el.addEventListener('mouseenter', () => {
+        if (gameRunning && !gameEnded) endGame(false);
+      });
+    }
+
+    if (item.type === 'start') {
+      el.id = 'start-point';
+      el.classList.add('waiting');
+      el.addEventListener('mouseenter', () => {
+        if (!gameRunning && !gameEnded) {
+          gameRunning = true;
+          el.classList.remove('waiting');
+        }
+      });
+    }
+
+    if (item.type === 'end') {
+      el.id = 'end-point';
+      el.addEventListener('mouseenter', () => {
+        if (gameRunning && !gameEnded) endGame(true);
+      });
+    }
+
+    mazeArea.appendChild(el);
+  });
+}
+
+function isMouseCollidingWithElement(el) {
+  const rect = el.getBoundingClientRect();
+  return (
+    mouseX + CURSOR_RADIUS >= rect.left &&
+    mouseX - CURSOR_RADIUS <= rect.right &&
+    mouseY + CURSOR_RADIUS >= rect.top &&
+    mouseY - CURSOR_RADIUS <= rect.bottom
+  );
+}
+
+// 장애물 상하 왕복 애니메이션
+function animateObstacles() {
+  if (gameEnded) return;
+
+  for (const obs of obstacles) {
+    obs.cur += obs.speed * obs.dir;
+
+    if (obs.cur >= obs.range) {
+      obs.cur = obs.range;
+      obs.dir = -1;
+    } else if (obs.cur <= 0) {
+      obs.cur = 0;
+      obs.dir = 1;
+    }
+
+    obs.el.style.top = obs.startY + obs.cur + '%';
+
+    if (gameRunning && mouseInsideMaze && isMouseCollidingWithElement(obs.el)) {
+      endGame(false);
+      return;
+    }
+  }
+
+  animFrameId = requestAnimationFrame(animateObstacles);
+}
+
+mazeArea.addEventListener('mousemove', (e) => {
+  const containerRect = container.getBoundingClientRect();
+  mouseX = e.clientX;
+  mouseY = e.clientY;
+  mouseInsideMaze = true;
+  cursorEl.style.left = e.clientX - containerRect.left + 'px';
+  cursorEl.style.top = e.clientY - containerRect.top + 'px';
+  cursorEl.style.display = 'block';
+
+  if (!gameRunning || gameEnded) return;
+
+  // 원이 닿는가
+  const edgePoints = [
+    [mouseX + CURSOR_RADIUS, mouseY],
+    [mouseX - CURSOR_RADIUS, mouseY],
+    [mouseX, mouseY + CURSOR_RADIUS],
+    [mouseX, mouseY - CURSOR_RADIUS],
+  ];
+
+  for (const [px, py] of edgePoints) {
+    const el = document.elementFromPoint(px, py);
+    if (
+      el &&
+      (el.classList.contains('wall') || el.classList.contains('obstacle'))
+    ) {
+      endGame(false);
+      return;
+    }
+  }
+});
+
+mazeArea.addEventListener('mouseenter', (e) => {
+  const containerRect = container.getBoundingClientRect();
+  mouseX = e.clientX;
+  mouseY = e.clientY;
+  mouseInsideMaze = true;
+  cursorEl.style.left = e.clientX - containerRect.left + 'px';
+  cursorEl.style.top = e.clientY - containerRect.top + 'px';
+  cursorEl.style.display = 'block';
+});
+
+mazeArea.addEventListener('mouseleave', () => {
+  mouseInsideMaze = false;
+  cursorEl.style.display = 'none';
+  if (gameRunning && !gameEnded) endGame(false);
+});
+
+// 성공/실패 처리 및 버튼 표시
+function endGame(success) {
+  if (gameEnded) return;
+
+  gameEnded = true;
+  gameRunning = false;
+  cancelAnimationFrame(animFrameId);
+  cursorEl.style.display = 'none';
+
+  if (success) {
+    startBtn.classList.add('hidden');
+    failBtns.classList.add('hidden');
+    nextBtn.classList.remove('hidden');
+  } else {
+    startBtn.classList.add('hidden');
+    failBtns.classList.remove('hidden');
+    nextBtn.classList.add('hidden');
+  }
+
+  messageEl.classList.remove('hidden');
+}
+
+function startGame() {
+  cancelAnimationFrame(animFrameId);
+  gameRunning = false;
+  gameEnded = false;
+  mouseInsideMaze = false;
+
+  startBtn.classList.add('hidden');
+  failBtns.classList.add('hidden');
+  nextBtn.classList.add('hidden');
+  messageEl.classList.add('hidden');
+  cursorEl.style.display = 'none';
+
+  buildMaze();
+  animateObstacles();
+}
+
+function onSuccess() {
+  // 다음 스테이지 이동 로직 추가 예정
+}
+
+function onFail() {
+  // 실패 시 어쩌지
+}
+
+startBtn.addEventListener('click', startGame);
+retryBtn.addEventListener('click', startGame);
+failBtn.addEventListener('click', onFail);
+nextBtn.addEventListener('click', onSuccess);

--- a/html/g_maze.html
+++ b/html/g_maze.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>미로 탈출</title>
+    <link rel="stylesheet" href="../style.css" />
+    <link rel="stylesheet" href="../g_maze/css/g_maze.css" />
+  </head>
+  <body>
+    <div id="root">
+      <header id="header">
+        <div class="logo">
+          <span>LOGO</span>
+        </div>
+        <div class="stage-info">
+          <span id="stage-name">현재 스테이지: 1단계</span>
+        </div>
+      </header>
+
+      <main id="container">
+        <div id="maze-guide">
+          <span>
+            초록색 시작 지점으로 들어가 게임을 시작하세요. 벽이나 장애물에
+            닿거나, 미로 밖으로 나가면 실패입니다.
+          </span>
+        </div>
+
+        <div id="maze-area"></div>
+
+        <div id="maze-cursor"></div>
+
+        <div id="ui">
+          <div id="message">
+            <button id="start-btn">시작</button>
+
+            <div class="btn-row hidden" id="fail-btns">
+              <button id="retry-btn">재시도</button>
+              <button id="fail-btn">수업 안 함</button>
+            </div>
+
+            <button id="next-btn" class="hidden">수업한다</button>
+          </div>
+        </div>
+      </main>
+    </div>
+
+    <script src="../g_maze/js/g_maze.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION

## 🔗 관련 Issue

  closes #30

  ---
 ## 📌 작업 내용

  - 'ㄹ' 모양 경로 + 가운데 지그재그 구간으로 구성된 고정 미로 레이아웃 설계
  - 마우스 이동 기반 벽·장애물 충돌 감지 구현 (커서 반지름 오프셋 적용)
  - 상하 왕복 장애물 2개 배치 및 정지 마우스와의 충돌 처리

  ---
 ## 🔧 변경 사항

  - 시작 지점 진입 시 게임 활성화, 미로 이탈 시 즉시 실패 처리
  - 커스텀 원형 커서 추가 (기본 커서 숨김)
  - 상단 안내 문구 바 추가

  ---
##  🧪 테스트 방법

  - 시작 버튼 클릭 후 좌상단 초록색 시작 지점으로 마우스 이동 → 게임 활성화 확인
  - 벽에 커서 끝이 닿을 시 실패 화면 전환 확인
  - 빨간 장애물에 닿을 시 실패 화면 전환 확인
  - 미로 영역 밖으로 커서 이탈 시 실패 화면 전환 확인
  - 우하단 노란색 도착 지점 진입 시 성공 화면 전환 확인
---

## 📸 스크린샷 (선택)

UI 변경 사항이 있다면 첨부해주세요.

---

## 💭 리뷰 포인트 (선택)

리뷰어가 중점적으로 확인해주었으면 하는 부분이 있다면 작성해주세요.
