### PR TITLE
feat: scroll, maze, stairs main.js 연동 및 스테이지 이동 구현 (#45)

### DIFF
--- a/g_maze/js/g_maze.js
+++ b/g_maze/js/g_maze.js
@@ -1,3 +1,6 @@
+localStorage.setItem('key', 9);
+getGuide('우리도 탈출 게임 있음 ㅇㅇ');
+
 const container = document.getElementById('container');
 const mazeArea = document.getElementById('maze-area');
 const messageEl = document.getElementById('message');
@@ -219,14 +222,9 @@ function startGame() {
 }
 
 function onSuccess() {
-  window.location.href = 'g_dark.html';
-}
-
-function onFail() {
-  //
+  throwLocalStorage(9);
 }
 
 startBtn.addEventListener('click', startGame);
 retryBtn.addEventListener('click', startGame);
-failBtn.addEventListener('click', onFail);
 nextBtn.addEventListener('click', onSuccess);

--- a/g_scroll/js/g_scroll.js
+++ b/g_scroll/js/g_scroll.js
@@ -1,3 +1,6 @@
+localStorage.setItem('key', 2);
+getGuide('ㅇㄱㅈㅉㅇㅇ?');
+
 export function initScroll(container, onNext) {
   const buttons = [
     { type: 'fake' },

--- a/g_stairs/js/g_stairs.js
+++ b/g_stairs/js/g_stairs.js
@@ -1,3 +1,6 @@
+localStorage.setItem('key', 12);
+getGuide('교수님의 점심을 지켜라');
+
 const GAME_W = 600;
 const STAIR_W = 143;
 const STEP_X = 85;
@@ -117,11 +120,7 @@ function move(dir) {
 }
 
 function onSuccess() {
-  // 마무리 엔딩 ㅊㅋㅊㅋ
-}
-
-function onFail() {
-  // 실패 시 이동 로직 추가 예정
+  throwLocalStorage(12);
 }
 
 function endGame(success) {
@@ -185,5 +184,4 @@ timerEl.textContent = TIME_LIMIT;
 
 startBtn.addEventListener('click', startGame);
 retryBtn.addEventListener('click', startGame);
-failBtn.addEventListener('click', onFail);
 nextBtn.addEventListener('click', onSuccess);

--- a/html/g_basic_screen.html
+++ b/html/g_basic_screen.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Game Layout Frame</title>
     <link rel="stylesheet" href="../g_basic_screen/css/g_basic_screen.css" />
-    <link rel="stylesheet" href="../style.css">
+    <link rel="stylesheet" href="../style.css" />
   </head>
   <body>
     <div id="root">
@@ -20,11 +20,13 @@
 
       <main id="container" class="background">
         <article id="buttons">
-            <button id="red-button" onclick="changeImageHandler()">수업 안함</button>
-            <button id="green-button">수업 한다</button>
+          <button id="red-button" onclick="changeImageHandler()">
+            수업 안함
+          </button>
+          <button id="green-button">수업 한다</button>
         </article>
       </main>
     </div>
     <script src="../g_basic_screen/js/g_basic_screen.js"></script>
-</body>
+  </body>
 </html>

--- a/html/g_maze.html
+++ b/html/g_maze.html
@@ -45,6 +45,7 @@
       </main>
     </div>
 
+    <script src="../main.js" defer></script>
     <script src="../g_maze/js/g_maze.js" defer></script>
   </body>
 </html>

--- a/html/g_scroll.html
+++ b/html/g_scroll.html
@@ -21,11 +21,12 @@
       <main id="container"></main>
     </div>
 
+    <script src="../main.js" defer></script>
     <script type="module">
       import { initScroll } from '../g_scroll/js/g_scroll.js';
 
       initScroll(document.getElementById('container'), () => {
-        window.location.href = 'g_timer.html';
+        throwLocalStorage(2);
       });
     </script>
   </body>

--- a/html/g_stairs.html
+++ b/html/g_stairs.html
@@ -45,6 +45,7 @@
       </main>
     </div>
 
+    <script src="../main.js" defer></script>
     <script src="../g_stairs/js/g_stairs.js" defer></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,44 +1,44 @@
-const pageList = 
-[
-  {id: 1, url: "/html/g_basic_screen.html"},
-  {id: 2, url: "/html/g_scroll.html"},
-  {id: 3, url: "/html/g_timer.html"},
-  {id: 4, url: "/html/g_rgb.html"},
-  {id: 5, url: "/html/g_drag.html"},
-  {id: 6, url: "/html/g_memory.html"},
-  {id: 7, url: "/html/g_line.html"},
-  {id: 8, url: "/html/g_roulette.html"},
-  {id: 9, url: "/html/g_maze.html"},
-  {id: 10, url: "/html/g_dark.html"},
-  {id: 11, url: "/html/g_photo.html"},
-  {id: 12, url: "/html/g_stairs.html"},
+const pageList = [
+  { id: 1, url: '/html/g_basic_screen.html' },
+  { id: 2, url: '/html/g_scroll.html' },
+  { id: 3, url: '/html/g_timer.html' },
+  { id: 4, url: '/html/g_rgb.html' },
+  { id: 5, url: '/html/g_drag.html' },
+  { id: 6, url: '/html/g_memory.html' },
+  { id: 7, url: '/html/g_line.html' },
+  { id: 8, url: '/html/g_roulette.html' },
+  { id: 9, url: '/html/g_maze.html' },
+  { id: 10, url: '/html/g_dark.html' },
+  { id: 11, url: '/html/g_photo.html' },
+  { id: 12, url: '/html/g_stairs.html' },
+  { id: 13, url: '/html/g_final_screen.html' },
 ];
 
 checkSaveLoadPage();
 
-function getGuide(gameDescription){
+function getGuide(gameDescription) {
   // 로컬스토리지에 저장된 페이지 번호 가져오기
   let stageNum = localStorage.getItem('key');
 
   // 헤더의 스테이지 설명 넣기
   const stageInput = document.getElementById('stage-name');
-  stageInput.innerText= `스테이지 ${stageNum} : ${gameDescription}`;
+  stageInput.innerText = `스테이지 ${stageNum} : ${gameDescription}`;
 }
 
 // 로컬 스토리지를 활용해서 페이지 넘기기
-function throwLocalStorage(stageNum){
-  window.location.href= pageList[stageNum].url;
+function throwLocalStorage(stageNum) {
+  window.location.href = pageList[stageNum].url;
 }
 
 // 1. localstorage null이 아닐 때 페이지 이동
 // 2. 해당 게임 다시 실행
-function loadThisPage(stageNum){
-  let stageBackNumber = stageNum -1;
-  window.location.href=pageList[stageBackNumber].url;
+function loadThisPage(stageNum) {
+  let stageBackNumber = stageNum - 1;
+  window.location.href = pageList[stageBackNumber].url;
 }
 
 // 페이지 불러오는 함수
-function checkSaveLoadPage(){
+function checkSaveLoadPage() {
   let stageNum = localStorage.getItem('key');
   if (stageNum !== null) {
     loadThisPage(stageNum);
@@ -46,7 +46,7 @@ function checkSaveLoadPage(){
 }
 
 // 처음으로 돌아가는 함수
-function returnPage(){
+function returnPage() {
   localStorage.setItem('key', 0);
-  window.location.href=pageList[0].url;
+  window.location.href = pageList[0].url;
 }


### PR DESCRIPTION
## 🔗 관련 Issue

closes #45

---

## 📌 작업 내용

- scroll·maze·stairs에 main.js 연동 (script 태그 추가)
- 각 게임 JS 상단에 localStorage key 저장 및 getGuide 호출
- 성공 시 throwLocalStorage로 다음 스테이지 이동 연결
- onFail 미구현 함수 및 이벤트 리스너 제거
- main.js pageList에 엔딩 화면(g_final_screen.html) id:13 추가

---

## 🔧 변경 사항

- scroll(2) → g_timer.html
- maze(9) → g_dark.html
- stairs(12) → g_final_screen.html

---

## 🧪 테스트 방법

- 각 게임 클리어 후 다음 페이지로 이동 확인
- 헤더에 `스테이지 N : 설명` 형식으로 표시 확인

---

## 💭 리뷰 포인트 (선택)
