### PR TITLE
feat: main.js 스테이지 관리 함수 재설계 및 게임 연동 (무한 reload bug 해결) (#48)

### DIFF
--- a/g_basic_screen/js/g_basic_screen.js
+++ b/g_basic_screen/js/g_basic_screen.js
@@ -1,3 +1,5 @@
+localStorage.setItem('key', 1);
+
 function changeImageHandler(){
     const container = document.getElementById("container")
     const button = document.getElementById("red-button")

--- a/g_maze/js/g_maze.js
+++ b/g_maze/js/g_maze.js
@@ -222,7 +222,7 @@ function startGame() {
 }
 
 function onSuccess() {
-  throwLocalStorage(9);
+  goNextStage();
 }
 
 startBtn.addEventListener('click', startGame);

--- a/g_stairs/js/g_stairs.js
+++ b/g_stairs/js/g_stairs.js
@@ -120,7 +120,7 @@ function move(dir) {
 }
 
 function onSuccess() {
-  throwLocalStorage(12);
+  goNextStage();
 }
 
 function endGame(success) {

--- a/html/g_basic_screen.html
+++ b/html/g_basic_screen.html
@@ -6,6 +6,7 @@
     <title>Game Layout Frame</title>
     <link rel="stylesheet" href="../g_basic_screen/css/g_basic_screen.css" />
     <link rel="stylesheet" href="../style.css" />
+    <script src="../main.js"></script>
   </head>
   <body>
     <div id="root">
@@ -23,7 +24,9 @@
           <button id="red-button" onclick="changeImageHandler()">
             수업 안함
           </button>
-          <button id="green-button">수업 한다</button>
+          <button id="green-button" onclick="goNextStage()">
+            수업 한다
+          </button>
         </article>
       </main>
     </div>

--- a/html/g_scroll.html
+++ b/html/g_scroll.html
@@ -15,6 +15,7 @@
         </div>
         <div class="stage-info">
           <span id="stage-name"></span>
+          <button onclick="resetAllStages()">리셋</button>
         </div>
       </header>
 
@@ -26,7 +27,7 @@
       import { initScroll } from '../g_scroll/js/g_scroll.js';
 
       initScroll(document.getElementById('container'), () => {
-        throwLocalStorage(2);
+        goNextStage();
       });
     </script>
   </body>

--- a/index.html
+++ b/index.html
@@ -5,19 +5,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Game Layout Frame</title>
     <link rel="stylesheet" href="style.css" />
+    <script src="main.js"></script>
   </head>
   <body>
-    <div id="root">
-      <header id="header">
-        <div class="logo">
-          <span>LOGO</span>
-        </div>
-        <div class="stage-info">
-          <span id="stage-name">현재 스테이지: 1단계</span>
-        </div>
-      </header>
-
-      <main id="container"></main>
-    </div>
+    <script>
+      checkSaveLoadPage();
+    </script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -14,39 +14,37 @@ const pageList = [
   { id: 13, url: '/html/g_final_screen.html' },
 ];
 
-checkSaveLoadPage();
-
+// 헤더에 띄우는 스테이지 번호와 게임명
 function getGuide(gameDescription) {
-  // 로컬스토리지에 저장된 페이지 번호 가져오기
   let stageNum = localStorage.getItem('key');
-
-  // 헤더의 스테이지 설명 넣기
   const stageInput = document.getElementById('stage-name');
   stageInput.innerText = `스테이지 ${stageNum} : ${gameDescription}`;
 }
 
-// 로컬 스토리지를 활용해서 페이지 넘기기
-function throwLocalStorage(stageNum) {
+// 다음 스테이지로 이동
+function goNextStage() {
+  let stageNum = localStorage.getItem('key');
   window.location.href = pageList[stageNum].url;
 }
 
-// 1. localstorage null이 아닐 때 페이지 이동
-// 2. 해당 게임 다시 실행
-function loadThisPage(stageNum) {
-  let stageBackNumber = stageNum - 1;
-  window.location.href = pageList[stageBackNumber].url;
+// 현재 스테이지 다시 하게 리로드하기
+function replayThisStage() {
+  let stageNum = localStorage.getItem('key');
+  window.location.href = pageList[stageNum - 1].url;
 }
 
-// 페이지 불러오는 함수
+// 접속 시 이어하기 판단 (index.html에서만 호출합니다)
 function checkSaveLoadPage() {
   let stageNum = localStorage.getItem('key');
-  if (stageNum !== null) {
-    loadThisPage(stageNum);
+  if (stageNum === null) {
+    window.location.href = '/html/g_basic_screen.html';
+    return;
   }
+  replayThisStage();
 }
 
-// 처음으로 돌아가는 함수
-function returnPage() {
-  localStorage.setItem('key', 0);
-  window.location.href = pageList[0].url;
+// 처음부터 다시 하기
+function resetAllStages() {
+  localStorage.removeItem('key');
+  window.location.href = '/index.html';
 }


### PR DESCRIPTION
## 🔗 관련 Issue

closes #48

---

## 📌 작업 내용

- main.js 스테이지 관리 함수 설계 및 명세 확정
- index.html, g_basic_screen, g_scroll, g_stairs, g_maze 연동

---

## 🔧 변경 사항

- `goNextStage()` : 다음 스테이지로 이동 (localStorage의 key값 기반)
- `replayThisStage()` : 현재 스테이지 다시 하기
- `checkSaveLoadPage()` : 접속 시 이어하기 판단, null이면 g_basic_screen으로 이동
- `resetAllStages()` : key 초기화 후 index.html로 이동
- `checkSaveLoadPage()`는 index.html에서만 호출하도록 변경 (무한 redirect 방지)
- 각 게임 JS 상단에 `localStorage.setItem('key', 스테이지번호)` 추가

---

## 🧪 테스트 방법

- localStorage를 비운 상태로 index.html 접속 → g_basic_screen으로 이동 확인
- g_basic_screen에서 '수업 한다' 버튼 클릭 → g_scroll로 이동 확인
- g_scroll 성공 후 → 다음 스테이지로 이동 확인
- localStorage에 key값이 있는 상태로 index.html 접속 → 해당 스테이지로 이동 확인

---

## 💭 리뷰 포인트

- 각 게임 JS 상단에 `localStorage.setItem('key', 스테이지번호)` 추가가 팀 컨벤션으로 확정되었습니다. 아직 연동되지 않은 게임 파일은 동일한 방식으로 추가 부탁드립니다!!
- `throwLocalStorage`, `loadThisPage`, `returnPage` 등 기존 함수명은 이번 PR에서 수정 혹은 제거되었습니다. 사용 중인 파일이 있다면 새 함수명으로 교체 필요합니다.